### PR TITLE
Update to support autoextend of sports recordings.

### DIFF
--- a/schedule-ui.xml
+++ b/schedule-ui.xml
@@ -1249,36 +1249,40 @@
             </checkbox>
 
             <spinbox name="priority" from="basespinbox">
-                <area>0,65,100%,40</area>
+                <area>0,55,100%,40</area>
                 <template type="negative">Reduce priority by %n</template>
                 <template type="zero">Normal recording priority</template>
                 <template type="positive">Raise priority by %n</template>
             </spinbox>
 
             <buttonlist name="input" from="baseselector">
-                <area>0,130,100%,40</area>
+                <area>0,110,100%,40</area>
             </buttonlist>
 
             <spinbox name="startoffset" from="basespinbox">
-                <area>0,195,100%,40</area>
+                <area>0,165,100%,40</area>
                 <template type="negative">Start recording %n minute(s) late</template>
                 <template type="zero">Start recording on time</template>
                 <template type="positive">Start recording %n minute(s) early</template>
             </spinbox>
 
             <spinbox name="endoffset" from="basespinbox">
-                <area>0,260,100%,40</area>
+                <area>0,220,100%,40</area>
                 <template type="negative">End recording %n minute(s) early</template>
                 <template type="zero">End recording on time</template>
                 <template type="positive">End recording %n minute(s) late</template>
             </spinbox>
 
             <buttonlist name="dupmethod" from="baseselector">
-                <area>0,325,100%,40</area>
+                <area>0,275,100%,40</area>
             </buttonlist>
 
             <buttonlist name="dupscope" from="baseselector">
-                <area>0,390,100%,40</area>
+                <area>0,330,100%,40</area>
+            </buttonlist>
+
+            <buttonlist name="autoextend" from="baseselector">
+                <area>0,385,100%,40</area>
             </buttonlist>
 
             <button name="filters" from="basebutton">

--- a/schedule-ui.xml
+++ b/schedule-ui.xml
@@ -1233,13 +1233,17 @@
             <filename>images/Backgrounds/BackgroundRecordings.jpg</filename>
             <area>0,0,100%,100%</area>
         </imagetype>
-        <group name="decoration" from="baseeditordecoration"/>
+        <group name="decoration" from="baseeditordecoration">
+            <group name="pagecontent">
+                <area>0,385,100%,100%</area>
+            </group>
+        </group>
         <textarea name="pagetitle" from="basepagetitletext">
             <value>Schedule Options</value>
         </textarea>
         <!-- left side -->
         <group name="controls">
-            <area>50,465,600,-115</area>
+            <area>50,400,600,-115</area>
             <textarea name="ruleactivelabel" from="baselabeltext">
                 <area>5,0,300,40</area>
                 <value>Recording Rule Active</value>
@@ -1281,6 +1285,10 @@
                 <area>0,390,100%,40</area>
             </buttonlist>
 
+            <buttonlist name="autoextend" from="baseselector">
+                <area>0,455,100%,40</area>
+            </buttonlist>
+
             <button name="filters" from="basebutton">
                 <area>0,100%-40,100%,40</area>
                 <value>Schedule filters</value>
@@ -1288,7 +1296,7 @@
         </group>
         <!-- right side -->
         <group name="details">
-            <area>700,465,-50,-115</area>
+            <area>700,400,-50,-115</area>
             <group name="titledesc" from="basetitledesc">
                 <area>0,0,100%,-120</area>
             </group>

--- a/schedule-ui.xml
+++ b/schedule-ui.xml
@@ -1249,40 +1249,36 @@
             </checkbox>
 
             <spinbox name="priority" from="basespinbox">
-                <area>0,55,100%,40</area>
+                <area>0,65,100%,40</area>
                 <template type="negative">Reduce priority by %n</template>
                 <template type="zero">Normal recording priority</template>
                 <template type="positive">Raise priority by %n</template>
             </spinbox>
 
             <buttonlist name="input" from="baseselector">
-                <area>0,110,100%,40</area>
+                <area>0,130,100%,40</area>
             </buttonlist>
 
             <spinbox name="startoffset" from="basespinbox">
-                <area>0,165,100%,40</area>
+                <area>0,195,100%,40</area>
                 <template type="negative">Start recording %n minute(s) late</template>
                 <template type="zero">Start recording on time</template>
                 <template type="positive">Start recording %n minute(s) early</template>
             </spinbox>
 
             <spinbox name="endoffset" from="basespinbox">
-                <area>0,220,100%,40</area>
+                <area>0,260,100%,40</area>
                 <template type="negative">End recording %n minute(s) early</template>
                 <template type="zero">End recording on time</template>
                 <template type="positive">End recording %n minute(s) late</template>
             </spinbox>
 
             <buttonlist name="dupmethod" from="baseselector">
-                <area>0,275,100%,40</area>
+                <area>0,325,100%,40</area>
             </buttonlist>
 
             <buttonlist name="dupscope" from="baseselector">
-                <area>0,330,100%,40</area>
-            </buttonlist>
-
-            <buttonlist name="autoextend" from="baseselector">
-                <area>0,385,100%,40</area>
+                <area>0,390,100%,40</area>
             </buttonlist>
 
             <button name="filters" from="basebutton">

--- a/themeinfo.xml
+++ b/themeinfo.xml
@@ -15,7 +15,7 @@
 
     <version>
         <major>5</major>
-        <minor>1</minor>
+        <minor>0</minor>
     </version>
 
     <detail>

--- a/themeinfo.xml
+++ b/themeinfo.xml
@@ -15,7 +15,7 @@
 
     <version>
         <major>5</major>
-        <minor>0</minor>
+        <minor>1</minor>
     </version>
 
     <detail>


### PR DESCRIPTION
Extending sports recordings can be done with one of two services. This adds an extra spinbox to the "Schedule Options" page of the recordings editor to allow you to choose the service.